### PR TITLE
Add TracknBuy Next.js PWA

### DIFF
--- a/CODEX_TRACKNBUY/.env.local.example
+++ b/CODEX_TRACKNBUY/.env.local.example
@@ -1,0 +1,22 @@
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=https://tnvhgjknvqpskosyrbur.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRudmhnamtudnZxcHNrb3N5cmJ1ciIsInJvbGUiOiJhbm9uIiwiaWF0IjoxNzUxMjAyMzAxLCJleHAiOjIwNjY3NzgzMDF9.zhS6RhORZGWAmknqmphCOkfJ5SqEa7Kj-nCAO-9qmqM
+
+# Vercel proxy for ScrapingDog
+NEXT_PUBLIC_PROXY_URL=https://tracknbuy-proxyv2.vercel.app/api/get-product
+SCRAPINGDOG_API_KEY=686149de2b7cec73d5b4d977
+
+# QuickChart
+NEXT_PUBLIC_QUICKCHART_BASE_URL=https://quickchart.io/chart
+
+# Gumroad
+GUMROAD_CHECKOUT_URL=https://tracknbuyai.gumroad.com/l/TracknBuyAIabcdef
+
+# Twilio (WhatsApp)
+TWILIO_ACCOUNT_SID=<TWILIO_SID>
+TWILIO_AUTH_TOKEN=<TWILIO_AUTH_TOKEN>
+TWILIO_WHATSAPP_FROM=whatsapp:+1234567890
+
+# Telegram Bot
+TELEGRAM_BOT_TOKEN=<TELEGRAM_BOT_TOKEN>
+TELEGRAM_CHAT_ID=<CHAT_ID>

--- a/CODEX_TRACKNBUY/README.md
+++ b/CODEX_TRACKNBUY/README.md
@@ -1,0 +1,23 @@
+# TracknBuy
+
+A price tracking Progressive Web App built with Next.js and Supabase.
+
+## Setup
+
+1. Copy `.env.local.example` to `.env.local` and fill in credentials.
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+3. Run database migrations on Supabase using `db/schema.sql`.
+4. Start the development server:
+
+```bash
+npm run dev
+```
+
+## Deployment
+
+Deploy on Vercel and connect to your Supabase project. Set environment variables from `.env.local` in Vercel. The app works well inside an iOS WebView when deployed as a PWA.

--- a/CODEX_TRACKNBUY/components/AddTrackerModal.tsx
+++ b/CODEX_TRACKNBUY/components/AddTrackerModal.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import Modal from './Modal';
+import { useAuth } from '../context/AuthContext';
+
+interface Props {
+  open: boolean;
+  onClose(): void;
+  onSaved(id: string): void;
+}
+
+export default function AddTrackerModal({ open, onClose, onSaved }: Props) {
+  const { supabase } = useAuth();
+  const [asinOrUrl, setAsinOrUrl] = useState('');
+  const [threshold, setThreshold] = useState('');
+  const [costPrice, setCostPrice] = useState('');
+  const [preview, setPreview] = useState<any>(null);
+
+  const fetchInfo = async () => {
+    const res = await fetch(`/api/proxy/get-product?url=${encodeURIComponent(asinOrUrl)}`);
+    const data = await res.json();
+    setPreview(data);
+  };
+
+  const save = async () => {
+    const { data, error } = await supabase.from('trackers').insert({
+      marketplace: 'Amazon',
+      asin: preview.asin,
+      product_url: preview.url,
+      threshold_price: Number(threshold) || null,
+      cost_price: Number(costPrice) || null,
+      last_checked_price: preview.price,
+      price_history: [{ price: preview.price, date: new Date().toISOString() }]
+    }).select().single();
+    if (!error && data) {
+      onSaved(data.id);
+      onClose();
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <h2 className="text-xl mb-4">Add New Tracker</h2>
+      <input
+        className="border p-2 w-full mb-2"
+        placeholder="ASIN or URL"
+        value={asinOrUrl}
+        onChange={e => setAsinOrUrl(e.target.value)}
+      />
+      <div className="flex space-x-2">
+        <input className="border p-2 w-full" placeholder="Threshold" value={threshold} onChange={e => setThreshold(e.target.value)} />
+        <input className="border p-2 w-full" placeholder="Cost" value={costPrice} onChange={e => setCostPrice(e.target.value)} />
+      </div>
+      <div className="my-2">
+        <button className="bg-gold text-white px-4 py-2 rounded" onClick={fetchInfo}>Fetch Info</button>
+      </div>
+      {preview && (
+        <div className="p-2 border my-2">
+          <img src={preview.image} className="w-20" />
+          <p>{preview.title}</p>
+          <p>{preview.price_symbol}{preview.price}</p>
+        </div>
+      )}
+      <div className="mt-4 flex justify-end">
+        <button className="bg-navy text-white px-4 py-2 rounded" onClick={save}>Save Tracker</button>
+      </div>
+    </Modal>
+  );
+}

--- a/CODEX_TRACKNBUY/components/Footer.tsx
+++ b/CODEX_TRACKNBUY/components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="bg-navy text-white p-4 text-center mt-auto">
+      &copy; {new Date().getFullYear()} TracknBuy
+    </footer>
+  );
+}

--- a/CODEX_TRACKNBUY/components/Header.tsx
+++ b/CODEX_TRACKNBUY/components/Header.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+import { useAuth } from '../context/AuthContext';
+
+export default function Header() {
+  const { user, signOut } = useAuth();
+  return (
+    <header className="bg-navy text-white p-4 flex justify-between items-center">
+      <Link href="/">
+        <span className="font-bold text-lg">TracknBuy</span>
+      </Link>
+      <nav className="space-x-4">
+        {user && <Link href="/dashboard">Dashboard</Link>}
+        {user ? (
+          <button onClick={signOut}>Logout</button>
+        ) : (
+          <Link href="/login">Login</Link>
+        )}
+      </nav>
+    </header>
+  );
+}

--- a/CODEX_TRACKNBUY/components/Modal.tsx
+++ b/CODEX_TRACKNBUY/components/Modal.tsx
@@ -1,0 +1,47 @@
+import { Fragment } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+
+interface ModalProps {
+  open: boolean;
+  onClose(): void;
+  children: React.ReactNode;
+}
+
+export default function Modal({ open, onClose, children }: ModalProps) {
+  return (
+    <Transition appear show={open} as={Fragment}>
+      <Dialog as="div" className="fixed inset-0 z-10 overflow-y-auto" onClose={onClose}>
+        <div className="min-h-screen px-4 text-center">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Dialog.Overlay className="fixed inset-0 bg-black opacity-30" />
+          </Transition.Child>
+
+          <span className="inline-block h-screen align-middle" aria-hidden="true">
+            &#8203;
+          </span>
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+          >
+            <div className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
+              {children}
+            </div>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/CODEX_TRACKNBUY/components/ProtectedRoute.tsx
+++ b/CODEX_TRACKNBUY/components/ProtectedRoute.tsx
@@ -1,0 +1,17 @@
+import { useAuth } from '../context/AuthContext';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export default function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user === null) {
+      router.push('/login');
+    }
+  }, [user, router]);
+
+  if (!user) return null;
+  return <>{children}</>;
+}

--- a/CODEX_TRACKNBUY/components/TrackerCard.tsx
+++ b/CODEX_TRACKNBUY/components/TrackerCard.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+interface Props {
+  tracker: any;
+}
+
+export default function TrackerCard({ tracker }: Props) {
+  return (
+    <div className="border p-4 rounded-2xl flex items-center space-x-4">
+      <img src={tracker.image_url || tracker.image} className="w-20" />
+      <div className="flex-1">
+        <h3 className="font-bold">{tracker.title}</h3>
+        <p>Last price: {tracker.last_checked_price}</p>
+      </div>
+      <Link href={`/trackers/${tracker.id}`} className="text-gold">View</Link>
+    </div>
+  );
+}

--- a/CODEX_TRACKNBUY/context/AuthContext.tsx
+++ b/CODEX_TRACKNBUY/context/AuthContext.tsx
@@ -1,0 +1,76 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { createClient, SupabaseClient, Session } from '@supabase/supabase-js';
+import bcrypt from 'bcryptjs';
+
+interface User {
+  id: string;
+  email: string;
+  status: string;
+  valid_until: string | null;
+}
+
+interface AuthContextProps {
+  user: User | null;
+  supabase: SupabaseClient;
+  signUp(email: string, password: string): Promise<void>;
+  signIn(email: string, password: string): Promise<void>;
+  signOut(): Promise<void>;
+  forgotPassword(email: string): Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextProps | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const session = supabase.auth.getSession();
+    session.then(({ data }) => setUser(data.session?.user as User));
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user as User);
+    });
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  const signUp = async (email: string, password: string) => {
+    const hashed = await bcrypt.hash(password, 10);
+    await supabase.from('users').insert({ email, password: hashed });
+    await signIn(email, password);
+  };
+
+  const signIn = async (email: string, password: string) => {
+    const { data } = await supabase.from('users').select('*').eq('email', email).single();
+    if (data && await bcrypt.compare(password, data.password)) {
+      await supabase.auth.signInWithPassword({ email, password });
+    } else {
+      throw new Error('Invalid credentials');
+    }
+  };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+    setUser(null);
+  };
+
+  const forgotPassword = async (email: string) => {
+    await supabase.auth.resetPasswordForEmail(email);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, supabase, signUp, signIn, signOut, forgotPassword }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error('useAuth must be used within AuthProvider');
+  return context;
+};

--- a/CODEX_TRACKNBUY/context/useRequirePremium.ts
+++ b/CODEX_TRACKNBUY/context/useRequirePremium.ts
@@ -1,0 +1,14 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { useAuth } from './AuthContext';
+
+export const useRequirePremium = () => {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!user) return;
+    const valid = user.status === 'active' && user.valid_until && new Date(user.valid_until) > new Date();
+    if (!valid) router.push('/subscription');
+  }, [user, router]);
+};

--- a/CODEX_TRACKNBUY/db/schema.sql
+++ b/CODEX_TRACKNBUY/db/schema.sql
@@ -1,0 +1,40 @@
+-- users
+create table users (
+  id uuid primary key default gen_random_uuid(),
+  email text unique not null,
+  password text not null,
+  status text not null default 'free',
+  valid_until timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- trackers
+create table trackers (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references users(id),
+  marketplace text not null,
+  asin text not null,
+  product_url text not null,
+  threshold_price numeric,
+  cost_price numeric,
+  last_checked_price numeric,
+  price_history jsonb default '[]',
+  sales_rank_history jsonb default '[]',
+  buy_box_history jsonb default '[]',
+  deals_history jsonb default '[]',
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- trending
+create table trending (
+  id uuid primary key default gen_random_uuid(),
+  asin text not null,
+  title text not null,
+  image_url text,
+  category text,
+  bestseller_rank integer,
+  price_drop_pct numeric,
+  date_tracked timestamptz default now()
+);

--- a/CODEX_TRACKNBUY/lib/cron.ts
+++ b/CODEX_TRACKNBUY/lib/cron.ts
@@ -1,0 +1,28 @@
+import cron from 'node-cron';
+import { createClient } from '@supabase/supabase-js';
+import { sendAlert } from './notifications';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
+
+export const scheduleTracking = () => {
+  const expr = '0 * * * *'; // hourly for free
+  cron.schedule(expr, async () => {
+    const { data: trackers } = await supabase.from('trackers').select('*');
+    if (!trackers) return;
+    for (const t of trackers) {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_PROXY_URL}?asin=${t.asin}&domain=fr`);
+      const d = await res.json();
+      await supabase.from('trackers').update({
+        last_checked_price: d.price,
+        price_history: [...t.price_history, { price: d.price, date: new Date().toISOString() }],
+        sales_rank_history: [...t.sales_rank_history, { rank: d.sales_rank, date: new Date().toISOString() }]
+      }).eq('id', t.id);
+      if ((t.threshold_price && d.price <= t.threshold_price) || d.limited_time_deal) {
+        await sendAlert(t.user_id, d);
+      }
+    }
+  });
+};

--- a/CODEX_TRACKNBUY/lib/notifications.ts
+++ b/CODEX_TRACKNBUY/lib/notifications.ts
@@ -1,0 +1,28 @@
+import { createClient } from '@supabase/supabase-js';
+import twilio from 'twilio';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
+
+const client = twilio(process.env.TWILIO_ACCOUNT_SID!, process.env.TWILIO_AUTH_TOKEN!);
+
+export const sendAlert = async (userId: string, data: any) => {
+  const { data: user } = await supabase.from('users').select('*').eq('id', userId).single();
+  const message = `Price alert for ${data.title}: ${data.price_symbol}${data.price}`;
+  if (process.env.TELEGRAM_BOT_TOKEN && process.env.TELEGRAM_CHAT_ID) {
+    await fetch(`https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: process.env.TELEGRAM_CHAT_ID, text: message })
+    });
+  }
+  if (process.env.TWILIO_WHATSAPP_FROM && user && user.phone) {
+    await client.messages.create({
+      from: process.env.TWILIO_WHATSAPP_FROM,
+      to: `whatsapp:${user.phone}`,
+      body: message
+    });
+  }
+};

--- a/CODEX_TRACKNBUY/next-env.d.ts
+++ b/CODEX_TRACKNBUY/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/CODEX_TRACKNBUY/next.config.js
+++ b/CODEX_TRACKNBUY/next.config.js
@@ -1,0 +1,8 @@
+const withPWA = require('next-pwa')({
+  dest: 'public',
+  disable: process.env.NODE_ENV === 'development'
+});
+
+module.exports = withPWA({
+  reactStrictMode: true
+});

--- a/CODEX_TRACKNBUY/package.json
+++ b/CODEX_TRACKNBUY/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "tracknbuy",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.6",
+    "autoprefixer": "^10.4.14",
+    "bcryptjs": "^2.4.3",
+    "next": "13.5.0",
+    "next-pwa": "^5.6.0",
+    "node-cron": "^3.0.2",
+    "postcss": "^8.4.14",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.3.0",
+    "twilio": "^4.14.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.4.2",
+    "@types/react": "18.2.14",
+    "@types/bcryptjs": "2.4.2",
+    "typescript": "5.2.2"
+  }
+}

--- a/CODEX_TRACKNBUY/pages/_app.tsx
+++ b/CODEX_TRACKNBUY/pages/_app.tsx
@@ -1,0 +1,11 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+import { AuthProvider } from '../context/AuthContext';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <AuthProvider>
+      <Component {...pageProps} />
+    </AuthProvider>
+  );
+}

--- a/CODEX_TRACKNBUY/pages/_document.tsx
+++ b/CODEX_TRACKNBUY/pages/_document.tsx
@@ -1,0 +1,17 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
+      </Head>
+      <body className="font-sans">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/CODEX_TRACKNBUY/pages/api/proxy/get-product.ts
+++ b/CODEX_TRACKNBUY/pages/api/proxy/get-product.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { asin, url, domain = 'fr' } = req.query;
+  const target = `${process.env.NEXT_PUBLIC_PROXY_URL}?asin=${asin || ''}&url=${url || ''}&domain=${domain}&api_key=${process.env.SCRAPINGDOG_API_KEY}`;
+  const response = await fetch(target);
+  const data = await response.json();
+  res.status(200).json(data);
+}

--- a/CODEX_TRACKNBUY/pages/api/webhooks/gumroad.ts
+++ b/CODEX_TRACKNBUY/pages/api/webhooks/gumroad.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { action } = req.query;
+  const { email } = req.body;
+
+  const { data: user } = await supabase.from('users').select('*').eq('email', email).single();
+  if (!user) return res.status(404).end();
+
+  if (req.method === 'POST') {
+    const event = req.body.event || req.body;
+    if (event === 'purchase_created' || event === 'subscription_renewed') {
+      const valid = new Date();
+      valid.setMonth(valid.getMonth() + 1);
+      await supabase.from('users').update({ status: 'active', valid_until: valid.toISOString() }).eq('id', user.id);
+    }
+    if (event === 'subscription_cancelled' || action === 'cancel') {
+      await supabase.from('users').update({ status: 'cancelled' }).eq('id', user.id);
+    }
+    res.status(200).end();
+  } else {
+    res.status(405).end();
+  }
+}

--- a/CODEX_TRACKNBUY/pages/dashboard.tsx
+++ b/CODEX_TRACKNBUY/pages/dashboard.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import AddTrackerModal from '../components/AddTrackerModal';
+import TrackerCard from '../components/TrackerCard';
+import ProtectedRoute from '../components/ProtectedRoute';
+import { useAuth } from '../context/AuthContext';
+
+export default function Dashboard() {
+  const { supabase, user } = useAuth();
+  const [trackers, setTrackers] = useState<any[]>([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    supabase.from('trackers').select('*').eq('user_id', user.id).then(({ data }) => setTrackers(data || []));
+  }, [supabase, user]);
+
+  const handleSaved = (id: string) => {
+    supabase.from('trackers').select('*').eq('id', id).single().then(({ data }) => {
+      if (data) setTrackers(prev => [...prev, data]);
+    });
+  };
+
+  return (
+    <ProtectedRoute>
+      <div className="flex flex-col min-h-screen">
+        <Header />
+        <main className="flex-1 p-4 space-y-4">
+          <button className="bg-gold text-white px-4 py-2 rounded" onClick={() => setOpen(true)}>
+            Add New
+          </button>
+          <div className="grid gap-4">
+            {trackers.map(t => (
+              <TrackerCard key={t.id} tracker={t} />
+            ))}
+          </div>
+        </main>
+        <Footer />
+        <AddTrackerModal open={open} onClose={() => setOpen(false)} onSaved={handleSaved} />
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/CODEX_TRACKNBUY/pages/index.tsx
+++ b/CODEX_TRACKNBUY/pages/index.tsx
@@ -1,0 +1,29 @@
+import Head from 'next/head';
+import { useState } from 'react';
+import AddTrackerModal from '../components/AddTrackerModal';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default function Home() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Head>
+        <title>TracknBuy</title>
+      </Head>
+      <Header />
+      <main className="flex-1 p-4 text-center">
+        <h1 className="text-3xl mb-4">Welcome to TracknBuy</h1>
+        <button className="bg-gold text-white px-4 py-2 rounded" onClick={() => setOpen(true)}>
+          Add New Tracker
+        </button>
+        <div className="mt-4">
+          <a href="/scan" className="text-gold underline">Scan Barcode</a>
+        </div>
+      </main>
+      <Footer />
+      <AddTrackerModal open={open} onClose={() => setOpen(false)} onSaved={() => {}} />
+    </div>
+  );
+}

--- a/CODEX_TRACKNBUY/pages/login.tsx
+++ b/CODEX_TRACKNBUY/pages/login.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import { useAuth } from '../context/AuthContext';
+
+export default function Login() {
+  const { signIn } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await signIn(email, password);
+    router.push('/dashboard');
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-1 p-4 flex justify-center items-center">
+        <form onSubmit={submit} className="space-y-4 w-80">
+          <input className="border p-2 w-full" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+          <input type="password" className="border p-2 w-full" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+          <button className="bg-navy text-white px-4 py-2 rounded w-full">Login</button>
+        </form>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/CODEX_TRACKNBUY/pages/scan.tsx
+++ b/CODEX_TRACKNBUY/pages/scan.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import Quagga from 'quagga';
+import { useRouter } from 'next/router';
+
+export default function Scan() {
+  const router = useRouter();
+
+  useEffect(() => {
+    Quagga.init({ inputStream: { name: 'Live', type: 'LiveStream' }, decoder: { readers: ['ean_reader'] } }, err => {
+      if (err) return;
+      Quagga.start();
+    });
+    Quagga.onDetected(data => {
+      const code = data.codeResult.code;
+      router.push(`/dashboard?add=${code}`);
+    });
+    return () => { Quagga.stop(); };
+  }, [router]);
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-1 p-4">
+        <div id="scanner" className="w-full h-96 bg-gray-200" />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/CODEX_TRACKNBUY/pages/subscription.tsx
+++ b/CODEX_TRACKNBUY/pages/subscription.tsx
@@ -1,0 +1,30 @@
+import { useRequirePremium } from '../context/useRequirePremium';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import { useAuth } from '../context/AuthContext';
+
+export default function Subscription() {
+  const { user } = useAuth();
+  const isPremium = user && user.status === 'active' && user.valid_until && new Date(user.valid_until) > new Date();
+  useRequirePremium();
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-1 p-4 text-center">
+        {isPremium ? (
+          <div>
+            <p>Your subscription is valid until {user!.valid_until}</p>
+            <form method="POST" action="/api/webhooks/gumroad?action=cancel">
+              <button className="bg-red-500 text-white px-4 py-2 rounded">Cancel Subscription</button>
+            </form>
+          </div>
+        ) : (
+          <a href={process.env.GUMROAD_CHECKOUT_URL} className="bg-gold text-white px-4 py-2 rounded">
+            Upgrade Now
+          </a>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/CODEX_TRACKNBUY/pages/trackers/[id].tsx
+++ b/CODEX_TRACKNBUY/pages/trackers/[id].tsx
@@ -1,0 +1,59 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import Header from '../../components/Header';
+import Footer from '../../components/Footer';
+import ProtectedRoute from '../../components/ProtectedRoute';
+import { useAuth } from '../../context/AuthContext';
+
+export default function TrackerDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { supabase } = useAuth();
+  const [tracker, setTracker] = useState<any>(null);
+  const [threshold, setThreshold] = useState('');
+
+  useEffect(() => {
+    if (!id) return;
+    supabase.from('trackers').select('*').eq('id', id).single().then(({ data }) => {
+      if (data) {
+        setTracker(data);
+        setThreshold(data.threshold_price || '');
+      }
+    });
+  }, [id, supabase]);
+
+  const save = async () => {
+    await supabase.from('trackers').update({ threshold_price: Number(threshold) || null }).eq('id', id);
+  };
+
+  const del = async () => {
+    await supabase.from('trackers').delete().eq('id', id);
+    router.push('/dashboard');
+  };
+
+  if (!tracker) return null;
+
+  const chartUrl = `${process.env.NEXT_PUBLIC_QUICKCHART_BASE_URL}?c=${encodeURIComponent(JSON.stringify({type:'line',data:{labels:tracker.price_history.map((p:any)=>p.date),datasets:[{label:'Price',data:tracker.price_history.map((p:any)=>p.price)}]}}))}`;
+
+  return (
+    <ProtectedRoute>
+      <div className="flex flex-col min-h-screen">
+        <Header />
+        <main className="flex-1 p-4 space-y-4">
+          <h1 className="text-2xl font-bold">{tracker.title}</h1>
+          <img src={tracker.image_url} className="w-40" />
+          <div>
+            <label>Threshold Price</label>
+            <input className="border p-2 w-full" value={threshold} onChange={e => setThreshold(e.target.value)} />
+          </div>
+          <img src={chartUrl} alt="Price history" />
+          <div className="space-x-2">
+            <button className="bg-gold text-white px-4 py-2 rounded" onClick={save}>Save Changes</button>
+            <button className="bg-red-500 text-white px-4 py-2 rounded" onClick={del}>Delete Tracker</button>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/CODEX_TRACKNBUY/postcss.config.js
+++ b/CODEX_TRACKNBUY/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/CODEX_TRACKNBUY/styles/globals.css
+++ b/CODEX_TRACKNBUY/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/CODEX_TRACKNBUY/tailwind.config.js
+++ b/CODEX_TRACKNBUY/tailwind.config.js
@@ -1,0 +1,19 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        navy: '#1E2A47',
+        gold: '#D4AF37'
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif']
+      }
+    }
+  },
+  plugins: []
+}

--- a/CODEX_TRACKNBUY/tsconfig.json
+++ b/CODEX_TRACKNBUY/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add TracknBuy Next.js app under `CODEX_TRACKNBUY`
- configure Tailwind, Next.js, and pwa
- implement Supabase auth context and premium hook
- add pages, API routes and cron/notification helpers
- provide database schema and environment example

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659860439483328caab7dff5dbcafc